### PR TITLE
Add build dir to gitignore, fix docs link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 **/__pycache__/
 *.pyc
+janis_pipelines.unix.egg-info/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repository contains common unix tools and data types for [Janis](https://github.com/PMCC-BioinformaticsCore/janis).
 
-Refer to the [documentation](https://janis.readthedocs.io/en/latest/tools/bioinformatics/index.html).
+Refer to the [documentation](https://janis.readthedocs.io/en/latest/tools/unix/index.html).
 
 
 ## Data types


### PR DESCRIPTION
Hi,

Reading the README for this project, found one link pointing to the bioinformatics tools docs, but I think we want users to be pointed to the unix one. Also added the egg build dir to gitignore (although I think we can use a glob instead, or ask devs/users to use the user global gitignore instead? happy to amend PR if needed).

Thanks
Bruno